### PR TITLE
SGE/virtualenv compatability fixes, fixes to sashimi_plot for headless mode

### DIFF
--- a/misopy/cluster_utils.py
+++ b/misopy/cluster_utils.py
@@ -146,6 +146,7 @@ def run_SGEarray_cluster(arg_list, argfile, cluster_output_dir,
     cs.write("done\n")
     cs.close()
 
+    os.system('chmod +x \"%s\"' %(cluster_script))
     qsub_cmd = cmd_name + ' \"%s\"' %(cluster_script)
 
     os.system(qsub_cmd)

--- a/misopy/cluster_utils.py
+++ b/misopy/cluster_utils.py
@@ -61,7 +61,7 @@ def run_SGEarray_cluster(arg_list, argfile, cluster_output_dir,
                          chunk=2500,
                          settings=None,
                          cmd_name="qsub",
-                         job_name="miso_job"):
+                         job_name="miso_job", preflight=None):
     """
     Run MISO jobs on cluster using SGE.
 
@@ -98,6 +98,7 @@ def run_SGEarray_cluster(arg_list, argfile, cluster_output_dir,
     if settings != None:
         load_settings(settings)
         cmd_name = Settings.get_cluster_command()
+	prflight_cmd = Settings.get_cluster_preflight()
 
     if queue_type == "long":
         queue_name = Settings.get_long_queue_name()
@@ -127,6 +128,8 @@ def run_SGEarray_cluster(arg_list, argfile, cluster_output_dir,
     cs.write("#$ -V\n") 
     if queue_name:
         cs.write("#$ -l %s\n" %(queue_name))
+    if preflight_cmd:
+	cs.write(preflight_cmd + "\n")
     cs.write("echo \"hostname is:\"\n")
     cs.write("hostname\n")
     cs.write("ARGFILE=%s\n" %argfile)

--- a/misopy/cluster_utils.py
+++ b/misopy/cluster_utils.py
@@ -98,7 +98,7 @@ def run_SGEarray_cluster(arg_list, argfile, cluster_output_dir,
     if settings != None:
         load_settings(settings)
         cmd_name = Settings.get_cluster_command()
-	prflight_cmd = Settings.get_cluster_preflight()
+	preflight_cmd = Settings.get_cluster_preflight()
 
     if queue_type == "long":
         queue_name = Settings.get_long_queue_name()

--- a/misopy/cluster_utils.py
+++ b/misopy/cluster_utils.py
@@ -61,7 +61,7 @@ def run_SGEarray_cluster(arg_list, argfile, cluster_output_dir,
                          chunk=2500,
                          settings=None,
                          cmd_name="qsub",
-                         job_name="miso_job", preflight=None):
+                         job_name="miso_job"):
     """
     Run MISO jobs on cluster using SGE.
 

--- a/misopy/sashimi_plot/Sashimi.py
+++ b/misopy/sashimi_plot/Sashimi.py
@@ -4,6 +4,7 @@
 import os
 
 import matplotlib
+matplotlib.use("PDF")
 import matplotlib.pyplot as plt
 from matplotlib import rc
 
@@ -20,8 +21,10 @@ class Sashimi:
         """
         Initialize image settings.
         """
+        plt.switch_backend("PDF")
         self.output_ext = ".pdf"
         if png:
+            plt.switch_backend("Agg")
             self.output_ext = ".png"
         
         # Plot label, will be used in creating the plot

--- a/misopy/settings.py
+++ b/misopy/settings.py
@@ -80,6 +80,17 @@ class Settings(object):
             return None
 
     @classmethod
+    def get_cluster_preflight(cls):
+        """
+        Return a command script to use to set up the cluster environment
+	before running MISO, e.g. altering PATH
+        """
+        if 'cluster_preflight' in cls.global_settings:
+            return cls.global_settings['cluster_preflight']
+        else:
+            return None
+
+    @classmethod
     def get_long_queue_name(cls):
         """
         Return the name of the long queue (for long jobs.)


### PR DESCRIPTION
SGE doesn't preserve local environmental variables, so to run MISO with `virtualenv`, the job script requires the ability to insert a "preflight" command to run the `activate` script. This adds a `preflight_cmd` setting to MISO which can insert arbitrary commands into the job script to execute before running MISO itself.

`sashimi_plot` doesn't require a GUI, so added a fix to the matplotlib import in order to use a headless image backend, thus obviating the need to do `ssh -X` on a remote server.
