### PR TITLE
fix import statement setup.py, required because entry_points is used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import distutils.ccompiler
 import glob
 import os


### PR DESCRIPTION
See https://chriswarrick.com/blog/2014/09/15/python-apps-the-right-way-entry_points-and-scripts/
The key part on that page is "You must use setuptools, otherwise this won’t work."

Without this trivial patch, installing MISO using "python setup.py install" doesn't work, i.e. no scripts are being installed to the `bin` subdirectory.
