### PR TITLE
Parse command string

### DIFF
--- a/misopy/cluster_utils.py
+++ b/misopy/cluster_utils.py
@@ -228,6 +228,7 @@ def launch_job(cluster_cmd, cmd_name):
     # submission system
     output = proc.communicate()
     job_id = None
+    cmd_name = cmd_name.split(" ")[0]
     if cmd_name == "qsub":
         if "." in output[0][:-1] and ">" not in output[0]:
             job_id = int(output[0].split(".")[0])
@@ -281,6 +282,7 @@ def wait_on_jobs(job_ids, cluster_cmd,
     """
     if len(job_ids) == 0:
         return
+    cluster_cmd = cluster_cmd.split(" ")[0]
     if cluster_cmd not in supported_cmds:
         return 
     num_jobs = len(job_ids)

--- a/misopy/run_events_analysis.py
+++ b/misopy/run_events_analysis.py
@@ -168,11 +168,11 @@ def check_gff_and_bam(gff_dir, bam_filename, main_logger,
     if bam_starts_with_chr != gff_starts_with_chr:
         mismatch_found = True
     if mismatch_found:
-        miso_logger.warning("It looks like your GFF annotation file and your BAM " \
+        main_logger.warning("It looks like your GFF annotation file and your BAM " \
                             "file might not have matching headers (chromosome names.) " \
                             "If this is the case, your run will fail as no reads from " \
                             "the BAM could be matched up with your annotation.")
-        miso_logger.warning("Please see:\n\t%s\n for more information." %(manual_url))
+        main_logger.warning("Please see:\n\t%s\n for more information." %(manual_url))
         # Default: assume BAM starts with chr headers
         chr_containing = "BAM file (%s)" %(bam_filename)
         not_chr_containing = "GFF annotation (%s)" %(gff_dir)
@@ -180,16 +180,16 @@ def check_gff_and_bam(gff_dir, bam_filename, main_logger,
             # BAM does not start with chr, GFF does
             chr_containing, not_chr_containing = \
                 not_chr_containing, chr_containing
-        miso_logger.warning("It looks like your %s contains \'chr\' chromosomes (UCSC-style) " \
+        main_logger.warning("It looks like your %s contains \'chr\' chromosomes (UCSC-style) " \
                             "while your %s does not." %(chr_containing,
                                                         not_chr_containing))
-        miso_logger.warning("The first few BAM chromosomes were: %s" \
+        main_logger.warning("The first few BAM chromosomes were: %s" \
                             %(",".join(bam_chroms.keys())))
         print "BAM references: "
         print bam_file.references
-        miso_logger.warning("The first few GFF chromosomes were: %s" \
+        main_logger.warning("The first few GFF chromosomes were: %s" \
                             %(",".join(gff_chroms.keys())))
-        miso_logger.warning("Run is likely to fail or produce empty output. Proceeding " \
+        main_logger.warning("Run is likely to fail or produce empty output. Proceeding " \
                             "anyway...")
         time.sleep(15)
 

--- a/misopy/samples_utils.py
+++ b/misopy/samples_utils.py
@@ -303,7 +303,7 @@ def summarize_sampler_results(samples_dir, summary_filename,
         counts_info = samples_results[5]
         shape_len = len(shape(samples))
         if shape_len < 2:
-            print "WARNING: Skipping %s -- mishaped file" %(samples_filename)
+            print "WARNING: Skipping %s -- mishaped file" %(event_name)
             continue
         num_samples, num_isoforms = shape(samples)
         output_fields = format_credible_intervals(event_name, samples)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import distutils.ccompiler
 import glob
 import os


### PR DESCRIPTION
When I use cluster in MISO, I configure cluster option something like this

```
[cluster]
cluster_command = qsub -l nodes=1:ppn=1
```

Cause I need to assign proper resourse to each jobs, I have to attach qsub option qsub command.

It makes problem in waiting on and launch jobs. So I just fix code. 

It doesn't make any change if you use

```
[cluster]
cluster_command = qsub
```

as basic guideline suggests

But it can makes you deal with give another option to miso cluster.

However, the way that add qsub option line to cluster setting file and make cluster_utils.py recognizes it can be more elaborated way to do this thing.

I can try it, if you reply this PR.

Thank you for reading.

Ingoo Lee from GIST
