### PR TITLE
fixing samtools sort output 

### DIFF
--- a/misopy/sam_to_bam.py
+++ b/misopy/sam_to_bam.py
@@ -25,8 +25,8 @@ def sam_to_bam(sam_filename, output_dir,
     # Sort
     print "Sorting BAM file..."
     sorted_filename = "%s.sorted" %(bam_filename.split(".bam")[0])
-    cmd = "samtools sort %s %s" %(bam_filename,
-                                  sorted_filename)
+    cmd = "samtools sort -o %s %s" %(sorted_filename,
+                                     bam_filename)
     print "  - Executing: %s" %(cmd)
     os.system(cmd)
 

--- a/misopy/sam_to_bam.py
+++ b/misopy/sam_to_bam.py
@@ -31,7 +31,7 @@ def sam_to_bam(sam_filename, output_dir,
     os.system(cmd)
 
     # Index
-    final_filename = "%s.bam" %(sorted_filename)
+    final_filename = "%s" %(sorted_filename)
     print "Indexing BAM..."
     cmd = "samtools index %s" %(final_filename)
     print "  - Executing: %s" %(cmd)

--- a/misopy/sam_to_bam.py
+++ b/misopy/sam_to_bam.py
@@ -24,7 +24,7 @@ def sam_to_bam(sam_filename, output_dir,
 
     # Sort
     print "Sorting BAM file..."
-    sorted_filename = "%s.sorted" %(bam_filename.split(".bam")[0])
+    sorted_filename = "%s.sorted.bam" %(bam_filename.split(".bam")[0])
     cmd = "samtools sort -o %s %s" %(sorted_filename,
                                      bam_filename)
     print "  - Executing: %s" %(cmd)


### PR DESCRIPTION
Samtools sort was missing the -o argument, which didn't work with current versions of samtools. I believe this fix will work starting with samtools 1.0 forward. May not work with earlier samtools. Could add in a samtools version check.
This resolves Issue 107, and perhaps 91. Has been tested locally.
