### PR TITLE
Fixed crashing on alignment files without sequence data 

### DIFF
--- a/misopy/pe_utils.py
+++ b/misopy/pe_utils.py
@@ -280,7 +280,7 @@ def compute_insert_len(bams_to_process,
             raise Exception, "Error: Insert length computation failed."
 
         # Load mapped BAM filename
-        mapped_bam = pysam.Samfile(mapped_bam_filename, "rb")
+        mapped_bam = pysam.AlignmentFile(mapped_bam_filename, "rb")
         ###
         ### TODO: Rewrite this so that you only pair reads within an interval
         ###

--- a/misopy/run_events_analysis.py
+++ b/misopy/run_events_analysis.py
@@ -92,7 +92,7 @@ def check_gff_and_bam(gff_dir, bam_filename, main_logger,
                             %(bam_index_fname))
         main_logger.warning("Are you sure your BAM file is indexed?")
     print "Checking if BAM has mixed read lengths..."
-    bam_file = pysam.Samfile(bam_filename, "rb")
+    bam_file = pysam.AlignmentFile(bam_filename, "rb")
     n = 0
     seq_lens = {}
     for bam_read in bam_file:
@@ -152,7 +152,7 @@ def check_gff_and_bam(gff_dir, bam_filename, main_logger,
                 gff_starts_with_chr = True
             n += 1
     # Read first few BAM reads chromosomes
-    bam_file = pysam.Samfile(bam_filename, "rb")
+    bam_file = pysam.AlignmentFile(bam_filename, "rb")
     bam_chroms = {}
     bam_starts_with_chr = False
     n = 0

--- a/misopy/run_events_analysis.py
+++ b/misopy/run_events_analysis.py
@@ -99,7 +99,7 @@ def check_gff_and_bam(gff_dir, bam_filename, main_logger,
         # Check more of the reads for mixed read lengths
         if n >= (num_reads * 10):
             break
-        seq_lens[len(bam_read.seq)] = True
+        seq_lens[bam_read.query_alignment_length] = True
         n += 1
     all_seq_lens = seq_lens.keys()
     if len(all_seq_lens) > 1:

--- a/misopy/sam_utils.py
+++ b/misopy/sam_utils.py
@@ -146,7 +146,7 @@ def load_bam_reads(bam_filename,
     """
     print "Loading BAM filename from: %s" %(bam_filename)
     bam_filename = os.path.abspath(os.path.expanduser(bam_filename))
-    bamfile = pysam.Samfile(bam_filename, "rb",
+    bamfile = pysam.AlignmentFile(bam_filename, "rb",
                             template=template)
     return bamfile
 

--- a/misopy/sashimi_plot/plot_utils/plot_gene.py
+++ b/misopy/sashimi_plot/plot_utils/plot_gene.py
@@ -45,7 +45,7 @@ def plot_density_single(settings, sample_label,
     Plot MISO events using BAM files and posterior distribution files.
     TODO: If comparison files are available, plot Bayes factors too.
     """
-    bamfile = pysam.Samfile(bam_filename, 'rb')
+    bamfile = pysam.AlignmentFile(bam_filename, 'rb')
     try:
         subset_reads = bamfile.fetch(reference=chrom, start=tx_start,end=tx_end)
     except ValueError as e:


### PR DESCRIPTION
@yarden  #112

While I was at it, I replaced pysam.Samfile with pysam.AlignmentFile everywhere I found it.