### PR TITLE
Fix custom plot label option with filenames

### DIFF
--- a/misopy/sashimi_plot/Sashimi.py
+++ b/misopy/sashimi_plot/Sashimi.py
@@ -88,10 +88,10 @@ class Sashimi:
         output_fname = None
         if plot_label is not None:
             # Use custom plot label if given
-            ext = self.output_filename.rsplit(".")[0]
+            ext = self.output_filename.rsplit(".")[1]
             dirname = os.path.dirname(self.output_filename)
             output_fname = \
-                os.path.dirname(dirname, "%s.%s" %(plot_label, ext))
+                os.path.join(dirname, "%s.%s" %(plot_label, ext))
         else:
             output_fname = self.output_filename
         print "Saving plot to: %s" %(output_fname)


### PR DESCRIPTION
This shouldn't change any other part of the program. It only intends to fix the fact that the `--plot-label` argument in `sashimi_plot` was not working properly.

I believe the `ext` variable meant to store the file extension, so it should be changed to the second index of the result from splitting the file on a period.

I know that on line 94, the `dirname` method is most likely not written correctly because it only accepts one parameter. https://docs.python.org/2.7/library/os.path.html#os.path.dirname

With my changes, I was able to get the plot-label to work allowing me to specify a new filename for each plot.